### PR TITLE
리소스와 관련된 id를 모두 받지 않도록 API 패스 간소화

### DIFF
--- a/src/main/java/com/marceldev/companylunchcomment/controller/CommentController.java
+++ b/src/main/java/com/marceldev/companylunchcomment/controller/CommentController.java
@@ -66,12 +66,12 @@ public class CommentController {
       summary = "코멘트 수정",
       description = "사용자는 자신이 작성한 코멘트를 수정할 수 있다."
   )
-  @PutMapping("/diners/{dinerId}/comments/{commentId}")
+  @PutMapping("/diners/comments/{id}")
   public CustomResponse<?> updateComment(
-      @PathVariable long commentId,
+      @PathVariable long id,
       @RequestBody UpdateCommentDto updateCommentDto
   ) {
-    commentService.updateComment(commentId, updateCommentDto);
+    commentService.updateComment(id, updateCommentDto);
     return CustomResponse.success();
   }
 
@@ -79,11 +79,11 @@ public class CommentController {
       summary = "코멘트 삭제",
       description = "사용자는 자신이 작성한 코멘트를 삭제할 수 있다."
   )
-  @DeleteMapping("/diners/{dinerId}/comments/{commentId}")
+  @DeleteMapping("/diners/comments/{id}")
   public CustomResponse<?> deleteComment(
-      @PathVariable long commentId
+      @PathVariable long id
   ) {
-    commentService.deleteComment(commentId);
+    commentService.deleteComment(id);
     return CustomResponse.success();
   }
 }

--- a/src/main/java/com/marceldev/companylunchcomment/controller/DinerController.java
+++ b/src/main/java/com/marceldev/companylunchcomment/controller/DinerController.java
@@ -141,12 +141,11 @@ public class DinerController {
   @Operation(
       summary = "식당 이미지 제거"
   )
-  @DeleteMapping("/diners/{dinerId}/images/{imageId}")
+  @DeleteMapping("/diners/images/{id}")
   public CustomResponse<?> removeDinerImage(
-      @PathVariable long dinerId,
-      @PathVariable long imageId
+      @PathVariable long id
   ) {
-    dinerImageService.removeDinerImage(dinerId, imageId);
+    dinerImageService.removeDinerImage(id);
     return CustomResponse.success();
   }
 

--- a/src/main/java/com/marceldev/companylunchcomment/controller/ReplyController.java
+++ b/src/main/java/com/marceldev/companylunchcomment/controller/ReplyController.java
@@ -30,13 +30,12 @@ public class ReplyController {
       summary = "댓글 작성",
       description = "사용자는 코멘트에 댓글을 작성할 수 있다."
   )
-  @PostMapping("/diners/{dinerId}/comments/{commentId}/replies")
+  @PostMapping("/comments/{id}/replies")
   public CustomResponse<?> createReply(
-      @PathVariable long dinerId,
-      @PathVariable long commentId,
+      @PathVariable long id,
       @Validated @RequestBody CreateReplyDto createReplyDto
   ) {
-    replyService.createReply(dinerId, commentId, createReplyDto);
+    replyService.createReply(id, createReplyDto);
     return CustomResponse.success();
   }
 
@@ -44,13 +43,12 @@ public class ReplyController {
       summary = "댓글 조회",
       description = "사용자는 코멘트에 작성된 댓글을 조회할 수 있다."
   )
-  @GetMapping("/diners/{dinerId}/comments/{commentId}/replies")
+  @GetMapping("/comments/{id}/replies")
   public CustomResponse<?> getReplyList(
-      @PathVariable long dinerId,
-      @PathVariable long commentId,
+      @PathVariable long id,
       Pageable pageable
   ) {
-    Page<ReplyOutputDto> replies = replyService.getReplyList(dinerId, commentId, pageable);
+    Page<ReplyOutputDto> replies = replyService.getReplyList(id, pageable);
     return CustomResponse.success(replies);
   }
 
@@ -59,13 +57,12 @@ public class ReplyController {
       description = "사용자는 코멘트에 댓글 수정이 가능하다.<br>"
           + "수정은 자신이 작성한 댓글만 가능하다."
   )
-  @PutMapping("/diners/{dinerId}/comments/{commentId}/replies/{replyId}")
+  @PutMapping("comments/replies/{id}")
   public CustomResponse<?> updateReply(
-      @PathVariable long dinerId,
-      @PathVariable long replyId,
+      @PathVariable long id,
       @Validated @RequestBody UpdateReplyDto updateReplyDto
   ) {
-    replyService.updateReply(dinerId, replyId, updateReplyDto);
+    replyService.updateReply(id, updateReplyDto);
     return CustomResponse.success();
   }
 
@@ -74,12 +71,11 @@ public class ReplyController {
       description = "사용자는 댓글 삭제가 가능하다.<br>"
           + "삭제는 자신이 작성한 댓글만 가능하다."
   )
-  @DeleteMapping("/diners/{dinerId}/comments/{commentId}/replies/{replyId}")
+  @DeleteMapping("/comments/replies/{id}")
   public CustomResponse<?> deleteReply(
-      @PathVariable long dinerId,
-      @PathVariable long replyId
+      @PathVariable long id
   ) {
-    replyService.deleteReply(dinerId, replyId);
+    replyService.deleteReply(id);
     return CustomResponse.success();
   }
 }

--- a/src/main/java/com/marceldev/companylunchcomment/dto/notification/RegisterFcmToken.java
+++ b/src/main/java/com/marceldev/companylunchcomment/dto/notification/RegisterFcmToken.java
@@ -1,7 +1,6 @@
 package com.marceldev.companylunchcomment.dto.notification;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/com/marceldev/companylunchcomment/repository/company/CompanyRepository.java
+++ b/src/main/java/com/marceldev/companylunchcomment/repository/company/CompanyRepository.java
@@ -1,13 +1,31 @@
 package com.marceldev.companylunchcomment.repository.company;
 
 import com.marceldev.companylunchcomment.entity.Company;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CompanyRepository extends JpaRepository<Company, Long> {
 
   boolean existsByDomainAndName(String domain, String name);
 
   Page<Company> findByDomain(String domain, Pageable pageable);
+
+  @Query("select c "
+      + "from Company c "
+      + "join Diner d on c.id = d.company.id "
+      + "join Comment cm on d.id = cm.diner.id "
+      + "join Reply r on cm.id = r.comment.id "
+      + "where r.id = :replyId")
+  Optional<Company> findCompanyByReplyId(@Param("replyId") long id);
+
+  @Query("select c "
+      + "from Company c "
+      + "join Diner d on c.id = d.company.id "
+      + "join Comment cm on d.id = cm.diner.id "
+      + "where cm.id = :commentId")
+  Optional<Company> findCompanyByCommentId(@Param("commentId") long id);
 }

--- a/src/main/java/com/marceldev/companylunchcomment/service/DinerImageService.java
+++ b/src/main/java/com/marceldev/companylunchcomment/service/DinerImageService.java
@@ -53,7 +53,7 @@ public class DinerImageService {
    * 식당 이미지 제거
    */
   @Transactional
-  public void removeDinerImage(long dinerId, long imageId) {
+  public void removeDinerImage(long imageId) {
     // dinerId는 추후에 사용자 개념이 들어오면, diner를 지울 수 있는지 확인할 때 쓰려고 남겨놓음
 
     DinerImage dinerImage = dinerImageRepository.findById(imageId)

--- a/src/main/java/com/marceldev/companylunchcomment/service/ReplyService.java
+++ b/src/main/java/com/marceldev/companylunchcomment/service/ReplyService.java
@@ -4,16 +4,16 @@ import com.marceldev.companylunchcomment.dto.reply.CreateReplyDto;
 import com.marceldev.companylunchcomment.dto.reply.ReplyOutputDto;
 import com.marceldev.companylunchcomment.dto.reply.UpdateReplyDto;
 import com.marceldev.companylunchcomment.entity.Comment;
-import com.marceldev.companylunchcomment.entity.Diner;
+import com.marceldev.companylunchcomment.entity.Company;
 import com.marceldev.companylunchcomment.entity.Member;
 import com.marceldev.companylunchcomment.entity.Reply;
 import com.marceldev.companylunchcomment.exception.CommentNotFoundException;
-import com.marceldev.companylunchcomment.exception.DinerNotFoundException;
+import com.marceldev.companylunchcomment.exception.CompanyNotExistException;
 import com.marceldev.companylunchcomment.exception.MemberNotExistException;
 import com.marceldev.companylunchcomment.exception.MemberUnauthorizedException;
 import com.marceldev.companylunchcomment.exception.ReplyNotFoundException;
 import com.marceldev.companylunchcomment.repository.comment.CommentRepository;
-import com.marceldev.companylunchcomment.repository.diner.DinerRepository;
+import com.marceldev.companylunchcomment.repository.company.CompanyRepository;
 import com.marceldev.companylunchcomment.repository.member.MemberRepository;
 import com.marceldev.companylunchcomment.repository.reply.ReplyRepository;
 import lombok.RequiredArgsConstructor;
@@ -34,15 +34,14 @@ public class ReplyService {
   private final CommentRepository commentRepository;
 
   private final MemberRepository memberRepository;
-
-  private final DinerRepository dinerRepository;
+  private final CompanyRepository companyRepository;
 
   /**
    * 댓글 작성
    */
   @Transactional
-  public void createReply(long dinerId, long commentId, CreateReplyDto dto) {
-    checkDiner(dinerId);
+  public void createReply(long commentId, CreateReplyDto dto) {
+    checkDinerByCommentId(commentId);
 
     Member member = getMember();
 
@@ -61,8 +60,8 @@ public class ReplyService {
   /**
    * 댓글 조회
    */
-  public Page<ReplyOutputDto> getReplyList(long dinerId, long commentId, Pageable pageable) {
-    checkDiner(dinerId);
+  public Page<ReplyOutputDto> getReplyList(long commentId, Pageable pageable) {
+    checkDinerByCommentId(commentId);
 
     Comment comment = commentRepository.findById(commentId)
         .orElseThrow(CommentNotFoundException::new);
@@ -85,8 +84,8 @@ public class ReplyService {
    * 댓글 수정
    */
   @Transactional
-  public void updateReply(long dinerId, long replyId, UpdateReplyDto dto) {
-    checkDiner(dinerId);
+  public void updateReply(long replyId, UpdateReplyDto dto) {
+    checkDinerByReplyId(replyId);
 
     Member member = getMember();
 
@@ -101,8 +100,8 @@ public class ReplyService {
    * 댓글 삭제
    */
   @Transactional
-  public void deleteReply(long dinerId, long replyId) {
-    checkDiner(dinerId);
+  public void deleteReply(long replyId) {
+    checkDinerByReplyId(replyId);
 
     Member member = getMember();
 
@@ -126,14 +125,29 @@ public class ReplyService {
   }
 
   /**
-   * diner에 접근할 수 있는지 검사
+   * diner 에 접근할 수 있는지 검사
    */
-  private void checkDiner(long dinerId) {
-    // member의 company를 체크하고, diner의 company를 체크해서 둘이 같은지 비교
+  private void checkDinerByCommentId(long id) {
     Member member = getMember();
-    Diner diner = dinerRepository.findById(dinerId)
-        .orElseThrow(() -> new DinerNotFoundException(dinerId));
-    if (!member.getCompany().getId().equals(diner.getCompany().getId())) {
+
+    Company company = companyRepository.findCompanyByCommentId(id)
+        .orElseThrow(CompanyNotExistException::new);
+
+    if (!member.getCompany().getId().equals(company.getId())) {
+      throw new MemberUnauthorizedException();
+    }
+  }
+
+  /**
+   * diner 에 접근할 수 있는지 검사
+   */
+  private void checkDinerByReplyId(long id) {
+    Member member = getMember();
+
+    Company company = companyRepository.findCompanyByReplyId(id)
+        .orElseThrow(CompanyNotExistException::new);
+
+    if (!member.getCompany().getId().equals(company.getId())) {
       throw new MemberUnauthorizedException();
     }
   }

--- a/src/test/java/com/marceldev/companylunchcomment/service/DinerImageServiceTest.java
+++ b/src/test/java/com/marceldev/companylunchcomment/service/DinerImageServiceTest.java
@@ -187,7 +187,7 @@ class DinerImageServiceTest {
         ));
 
     //when
-    dinerImageService.removeDinerImage(1L, 1L);
+    dinerImageService.removeDinerImage(1L);
     ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 
     //then
@@ -206,7 +206,7 @@ class DinerImageServiceTest {
     //when
     //then
     assertThrows(DinerImageNotFoundException.class,
-        () -> dinerImageService.removeDinerImage(1L, 1L));
+        () -> dinerImageService.removeDinerImage(1L));
   }
 
   @Test
@@ -227,7 +227,7 @@ class DinerImageServiceTest {
     //when
     //then
     assertThrows(ImageDeleteFail.class,
-        () -> dinerImageService.removeDinerImage(1L, 1L));
+        () -> dinerImageService.removeDinerImage(1L));
   }
 
   @Test
@@ -249,6 +249,6 @@ class DinerImageServiceTest {
     //when
     //then
     assertThrows(InternalServerError.class,
-        () -> dinerImageService.removeDinerImage(1L, 1L));
+        () -> dinerImageService.removeDinerImage(1L));
   }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- API에서 리소스의 id를 여럿을 받는 경우가 있음
- 예를 들어, commentId로 comment를 특정할 수 있는데, dinerId까지 같이 받는 형식

**TO-BE**
- 리소스의 id를 한개만 받도록 수정
  - dinerId와 commentId를 같이 받던 곳에서 commentId만 받도록 함
  - dinerId를 통해서 사용자가 접근 가능한 diner인지 검사하는 로직은 commentId로부터 dinerId를 가져오는 식으로 수정
  - comment와 reply 둘의 id를 모두 받는 곳도 하나로 수정
  - diner와 image 둘의 id를 모두 받는 곳도 하나로 수정

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
  - 테스트를 통과하도록 코드 수정
- [x] API 테스트
  - PUT, DELETE /diners/comments/{id}
  - DELETE /diners/images/{id} 
  - POST, GET /comments/{id}/replies
  - PUT, DELETE /comments/replies/{id}

Resolve #37 